### PR TITLE
Concurrency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	go.uber.org/dig v1.17.1 // indirect
 	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+	golang.org/x/time v0.5.0 // indirect
 )


### PR DESCRIPTION
# Description

Concurrent calls to rpc allows to achive much faster performance (around 2s vs. 18s with sequential calls).

## Implementation Details

The erc20 transactions of each of the previous 100 blocks are fetched in a separate goroutine and the addresses are put into a buffered channel. The channel is closed when all goroutines finish the execition. A mutex is used to lock reading/writing to the activity map allowing for thread safety. A rate limiter is used to limit for 25 rpc calls per second, since I encouterd error 429. 